### PR TITLE
FIX: Add port to FTP connection

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -47,7 +47,7 @@ echo 'Tar Complete'
 
 if [ $TYPE -eq 1 ]
 then
-ftp -n -i $SERVER <<EOF
+ftp -n -i $SERVER $PORT <<EOF
 user $USERNAME $PASSWORD
 binary
 put $FILE $REMOTEDIR/$FILE


### PR DESCRIPTION
When the port is different from 21, an authentication error occurred. Now it works correctly.